### PR TITLE
Prevent scrot from beeping

### DIFF
--- a/i3lock-wrapper
+++ b/i3lock-wrapper
@@ -148,7 +148,7 @@ arg_test $@
 file1=$(mktemp --tmpdir i3lock-wrapper-XXXXXXXXXX.png)
 file2=$(mktemp --tmpdir i3lock-wrapper-XXXXXXXXXX.png)
 
-scrot -d0 "$file1"
+scrot -z -d0 "$file1"
 convert "$file1" -blur 0x3 "$file2"
 rm "$file1" # Remove for security
 


### PR DESCRIPTION
It's starting to be anoying that `i3lock-wrapper` beep before locking.

This is a simple fix to pass `-z` to `scrot` to prevent from beeping.
From manual page:

```
       -z, --silent
            prevent beeping.
```

If there was another way of silent the beep, *pardon* in advance.