### PR TITLE
Rebase window-icons patch to 4.11

### DIFF
--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -1,6 +1,6 @@
-From f0816ebf4e536a41e5f91c0727f21504eb325d41 Mon Sep 17 00:00:00 2001
+From 7f45c393ee8a9dbe35b7c6128d1c87bc540c7a5a Mon Sep 17 00:00:00 2001
 From: Marius Muja <mariusm@cs.ubc.ca>
-Date: Wed, 26 Dec 2012 20:37:08 -0800
+Date: Wed, 14 Oct 2015 10:04:14 +0200
 Subject: [PATCH] Added support for window icons (_NET_WM_ICON property)
 
 ---
@@ -8,26 +8,25 @@ Subject: [PATCH] Added support for window icons (_NET_WM_ICON property)
  include/atoms.xmacro |  1 +
  include/data.h       |  5 ++++
  include/window.h     |  9 ++++++
- src/manage.c         | 10 ++++++-
+ src/manage.c         | 11 ++++++++
  src/render.c         |  5 ++++
  src/tree.c           |  3 ++
- src/window.c         | 81 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ src/window.c         | 80 ++++++++++++++++++++++++++++++++++++++++++++++++++++
  src/x.c              | 78 ++++++++++++++++++++++++++++++++++++++++++++++++++
- 9 files changed, 198 insertions(+), 1 deletion(-)
+ 9 files changed, 199 insertions(+)
 
 diff --git a/common.mk b/common.mk
-index b946206..54ae8b4 100644
+index d287504..b303bd3 100644
 --- a/common.mk
 +++ b/common.mk
-@@ -1,6 +1,7 @@
+@@ -1,5 +1,6 @@
  UNAME=$(shell uname)
  DEBUG=1
- COVERAGE=0
 +USE_ICONS=1
  INSTALL=install
  LN=ln
- ifndef PREFIX
-@@ -56,6 +57,9 @@ I3_CPPFLAGS += -DMINOR_VERSION=${MINOR_VERSION}
+ PKG_CONFIG=pkg-config
+@@ -59,6 +60,9 @@ I3_CPPFLAGS += -DMINOR_VERSION=${MINOR_VERSION}
  I3_CPPFLAGS += -DPATCH_VERSION=${PATCH_VERSION}
  I3_CPPFLAGS += -DSYSCONFDIR=\"${SYSCONFDIR}\"
  I3_CPPFLAGS += -DI3__FILE__=__FILE__
@@ -37,7 +36,7 @@ index b946206..54ae8b4 100644
  
  
  ## Libraries flags
-@@ -104,6 +108,9 @@ XCB_WM_CFLAGS += $(call cflags_for_lib, xcb-randr)
+@@ -108,6 +112,9 @@ XCB_WM_CFLAGS += $(call cflags_for_lib, xcb-randr)
  XCB_WM_LIBS   := $(call ldflags_for_lib, xcb-icccm,xcb-icccm)
  XCB_WM_LIBS   += $(call ldflags_for_lib, xcb-xinerama,xcb-xinerama)
  XCB_WM_LIBS   += $(call ldflags_for_lib, xcb-randr,xcb-randr)
@@ -45,14 +44,14 @@ index b946206..54ae8b4 100644
 +XCB_WM_LIBS   += $(call ldflags_for_lib, xcb-image,xcb-image)
 +endif
  
- # Xlib
- X11_CFLAGS := $(call cflags_for_lib, x11)
+ XKB_COMMON_CFLAGS := $(call cflags_for_lib, xkbcommon,xkbcommon)
+ XKB_COMMON_LIBS := $(call ldflags_for_lib, xkbcommon,xkbcommon)
 diff --git a/include/atoms.xmacro b/include/atoms.xmacro
-index e6e72e7..e472c2a 100644
+index f856559..79b7838 100644
 --- a/include/atoms.xmacro
 +++ b/include/atoms.xmacro
-@@ -17,6 +17,7 @@ xmacro(_NET_CURRENT_DESKTOP)
- xmacro(_NET_ACTIVE_WINDOW)
+@@ -32,6 +32,7 @@ xmacro(_NET_ACTIVE_WINDOW)
+ xmacro(_NET_CLOSE_WINDOW)
  xmacro(_NET_STARTUP_ID)
  xmacro(_NET_WORKAREA)
 +xmacro(_NET_WM_ICON)
@@ -60,13 +59,13 @@ index e6e72e7..e472c2a 100644
  xmacro(WM_DELETE_WINDOW)
  xmacro(UTF8_STRING)
 diff --git a/include/data.h b/include/data.h
-index 6fc7b40..d469c87 100644
+index 58e4a00..b6c412f 100644
 --- a/include/data.h
 +++ b/include/data.h
-@@ -366,6 +366,11 @@ struct Window {
+@@ -421,6 +421,11 @@ struct Window {
  
-     /** Depth of the window */
-     uint16_t depth;
+     /* aspect ratio from WM_NORMAL_HINTS (MPlayer uses this for example) */
+     double aspect_ratio;
 +
 +#ifdef USE_ICONS
 +    /** Window icon, array of size 16x16 containing the ARGB pixels */
@@ -76,13 +75,13 @@ index 6fc7b40..d469c87 100644
  
  /**
 diff --git a/include/window.h b/include/window.h
-index 480cee1..04a6841 100644
+index 395c988..f7a928d 100644
 --- a/include/window.h
 +++ b/include/window.h
-@@ -75,3 +75,12 @@ void window_update_hints(i3Window *win, xcb_get_property_reply_t *prop, bool *ur
-  *
+@@ -68,6 +68,15 @@ void window_update_type(i3Window *window, xcb_get_property_reply_t *reply);
   */
- void window_update_motif_hints(i3Window *win, xcb_get_property_reply_t *prop, border_style_t *motif_border_style);
+ void window_update_hints(i3Window *win, xcb_get_property_reply_t *prop, bool *urgency_hint);
+ 
 +
 +#ifdef USE_ICONS
 +/**
@@ -90,48 +89,52 @@ index 480cee1..04a6841 100644
 + *
 + */
 +void window_update_icon(i3Window *win, xcb_get_property_reply_t *prop);
-+
 +#endif
++
+ /**
+  * Updates the MOTIF_WM_HINTS. The container's border style should be set to
+  * `motif_border_style' if border style is not BS_NORMAL.
 diff --git a/src/manage.c b/src/manage.c
-index d84ba1b..7525020 100644
+index e376967..891182f 100644
 --- a/src/manage.c
 +++ b/src/manage.c
-@@ -120,7 +120,9 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
-                               class_cookie, leader_cookie, transient_cookie,
-                               role_cookie, startup_id_cookie, wm_hints_cookie,
-                               motif_wm_hints_cookie;
--
-+#ifdef USE_ICONS                              
+@@ -92,6 +92,10 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
+         role_cookie, startup_id_cookie, wm_hints_cookie,
+         wm_normal_hints_cookie, motif_wm_hints_cookie;
+ 
++#ifdef USE_ICONS
 +    xcb_get_property_cookie_t wm_icon_cookie;
 +#endif
- 
++
      geomc = xcb_get_geometry(conn, d);
  
-@@ -190,6 +192,9 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
-     startup_id_cookie = GET_PROPERTY(A__NET_STARTUP_ID, 512);
+     /* Check if the window is mapped (it could be not mapped when intializing and
+@@ -161,6 +165,9 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
      wm_hints_cookie = xcb_icccm_get_wm_hints(conn, window);
+     wm_normal_hints_cookie = xcb_icccm_get_wm_normal_hints(conn, window);
      motif_wm_hints_cookie = GET_PROPERTY(A__MOTIF_WM_HINTS, 5 * sizeof(uint64_t));
 +#ifdef USE_ICONS
 +    wm_icon_cookie = xcb_get_property_unchecked(conn, false, window, A__NET_WM_ICON, XCB_ATOM_CARDINAL, 0, UINT32_MAX);
 +#endif
-     /* TODO: also get wm_normal_hints here. implement after we got rid of xcb-event */
  
      DLOG("Managing window 0x%08x\n", window);
-@@ -226,6 +231,9 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
+ 
+@@ -187,6 +194,10 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
      window_update_hints(cwindow, xcb_get_property_reply(conn, wm_hints_cookie, NULL), &urgency_hint);
      border_style_t motif_border_style = BS_NORMAL;
      window_update_motif_hints(cwindow, xcb_get_property_reply(conn, motif_wm_hints_cookie, NULL), &motif_border_style);
 +#ifdef USE_ICONS
 +    window_update_icon(cwindow, xcb_get_property_reply(conn, wm_icon_cookie, NULL));
 +#endif
- 
-     xcb_get_property_reply_t *startup_id_reply;
-     startup_id_reply = xcb_get_property_reply(conn, startup_id_cookie, NULL);
++
+     xcb_size_hints_t wm_size_hints;
+     if (!xcb_icccm_get_wm_size_hints_reply(conn, wm_normal_hints_cookie, &wm_size_hints, NULL))
+         memset(&wm_size_hints, '\0', sizeof(xcb_size_hints_t));
 diff --git a/src/render.c b/src/render.c
-index f996d96..a22e9cc 100644
+index 7ada19e..9eecf4b 100644
 --- a/src/render.c
 +++ b/src/render.c
-@@ -215,6 +215,11 @@ void render_con(Con *con, bool render_fullscreen) {
+@@ -223,6 +223,11 @@ void render_con(Con *con, bool render_fullscreen) {
  
      /* find the height for the decorations */
      int deco_height = render_deco_height();
@@ -144,28 +147,27 @@ index f996d96..a22e9cc 100644
      /* precalculate the sizes to be able to correct rounding errors */
      int sizes[children];
 diff --git a/src/tree.c b/src/tree.c
-index 48ab163..a7b8e64 100644
+index 1d06d87..bbd5548 100644
 --- a/src/tree.c
 +++ b/src/tree.c
-@@ -260,6 +260,9 @@ bool tree_close(Con *con, kill_window_t kill_window, bool dont_kill_parent, bool
+@@ -268,6 +268,9 @@ bool tree_close(Con *con, kill_window_t kill_window, bool dont_kill_parent, bool
          FREE(con->window->class_class);
          FREE(con->window->class_instance);
          i3string_free(con->window->name);
 +#ifdef USE_ICONS
 +        FREE(con->window->icon);
 +#endif
-         free(con->window);
+         FREE(con->window->ran_assignments);
+         FREE(con->window);
      }
- 
 diff --git a/src/window.c b/src/window.c
-index c3a35cf..e015a32 100644
+index 5898333..0ad7d01 100644
 --- a/src/window.c
 +++ b/src/window.c
-@@ -310,3 +310,84 @@ void window_update_motif_hints(i3Window *win, xcb_get_property_reply_t *prop, bo
- #undef MWM_DECOR_BORDER
- #undef MWM_DECOR_TITLE
+@@ -406,3 +406,83 @@ i3String *window_parse_title_format(i3Window *win) {
+     i3string_set_markup(formatted, is_markup);
+     return formatted;
  }
-+
 +
 +#ifdef USE_ICONS
 +/*
@@ -201,7 +203,7 @@ index c3a35cf..e015a32 100644
 +    uint64_t len = 0;
 +
 +    if(!prop || prop->type != XCB_ATOM_CARDINAL || prop->format != 32) {
-+    		DLOG("_NET_WM_ICON is not set\n");
++        DLOG("_NET_WM_ICON is not set\n");
 +        FREE(prop);
 +        return;
 +    }
@@ -247,7 +249,7 @@ index c3a35cf..e015a32 100644
 +}
 +#endif /* USE_ICONS */
 diff --git a/src/x.c b/src/x.c
-index b3af85a..ab20ad3 100644
+index 9b9ba6a..226b9fb 100644
 --- a/src/x.c
 +++ b/src/x.c
 @@ -11,6 +11,9 @@
@@ -258,9 +260,9 @@ index b3af85a..ab20ad3 100644
 +#include <xcb/xcb_image.h>
 +#endif
  
- /* Stores the X11 window ID of the currently focused window */
- xcb_window_t focused_id = XCB_NONE;
-@@ -294,6 +297,44 @@ void x_window_kill(xcb_window_t window, kill_window_t kill_window) {
+ xcb_window_t ewmh_window;
+ 
+@@ -312,6 +315,44 @@ void x_window_kill(xcb_window_t window, kill_window_t kill_window) {
      free(event);
  }
  
@@ -305,7 +307,7 @@ index b3af85a..ab20ad3 100644
  /*
   * Draws the decoration of the given container onto its parent.
   *
-@@ -527,12 +568,49 @@ void x_draw_decoration(Con *con) {
+@@ -543,6 +584,9 @@ void x_draw_decoration(Con *con) {
      }
      //DLOG("indent_level = %d, indent_mult = %d\n", indent_level, indent_mult);
      int indent_px = (indent_level * 5) * indent_mult;
@@ -313,10 +315,11 @@ index b3af85a..ab20ad3 100644
 +    if (win->icon) indent_px += 18;
 +#endif
  
-     draw_text(win->name,
-             parent->pixmap, parent->pm_gc,
-             con->deco_rect.x + 2 + indent_px, con->deco_rect.y + text_offset_y,
-             con->deco_rect.width - 2 - indent_px);
+     int mark_width = 0;
+     if (config.show_marks && con->mark != NULL && (con->mark)[0] != '_') {
+@@ -567,6 +611,40 @@ void x_draw_decoration(Con *con) {
+     if (win->title_format != NULL)
+         I3STRING_FREE(title);
  
 +#ifdef USE_ICONS
 +    /* Draw the icon */
@@ -337,7 +340,7 @@ index b3af85a..ab20ad3 100644
 +                width*height*4,
 +                (uint8_t*)icon_pixels
 +                );
-+                
++
 +        if (icon) {
 +            int icon_offset_y = (con->deco_rect.height - 16) / 2;
 +
@@ -356,5 +359,5 @@ index b3af85a..ab20ad3 100644
      /* Since we don’t clip the text at all, it might in some cases be painted
       * on the border pixels on the right side of a window. Therefore, we draw
 -- 
-2.0.0
+2.4.3
 


### PR DESCRIPTION
Applied the patch to 4.10.2, rebased on 4.11 and resolved conflicts.