### PR TITLE
Removed the dpms options

### DIFF
--- a/i3lock-wrapper
+++ b/i3lock-wrapper
@@ -19,7 +19,7 @@ set -e
 script_name=$(basename $0)
 params=$(getopt \
          -o vnbdI:up:eflh \
-         -l version,nofork,beep,dpms,inactivity-timeout:,no-unlock-indicator,pointer:,ignore-empty-password,show-failed-attempts,logo,help \
+         -l version,nofork,beep,,no-unlock-indicator,pointer:,ignore-empty-password,show-failed-attempts,logo,help \
          -n "$script_name" -- "$@")
 eval set -- "$params"
 # exit on bad arguments
@@ -37,11 +37,6 @@ Usage: $script_name [options]
     -v, --version               version of the i3lock.
     -n, --nofork                don't fork i3lock after start.
     -b, --beep                  enable beeping.
-    -d, --dpms                  enable turning off the screen with DPMS.
-    -I sec,
-    --inactivity-timeout=sec    specifies  the  number of seconds i3lock will 
-                                wait for another password before turning
-                                off the monitors.
     -u, --no-unlock-indicator   disable the unlock indicator.
     -p win|default, 
     --pointer=win|default       do not hide the mouse pointer on default
@@ -67,20 +62,6 @@ arg_test () {
                shift;;
            -b|--beep)              
                shift;;
-           -d|--dpms)                  
-               shift;;
-           -I|--inactivity-timeout)
-               shift
-               case "$1" in
-                   [0-9]*)
-                       shift;;
-                    *)
-                       echo "$script_name: invalid option \"$1\" for argument -I" \
-                            "number expected" >&2
-                       exit 1
-                       ;;
-               esac
-               ;;
            -u|--no-unlock-indicator)   
                shift;;
            -p|--pointer) 


### PR DESCRIPTION
This branch removes the dpms and inactivity-timeout options, since they've been removed from i3lock.