### PR TITLE
update window-icons/window-icons.patch

### DIFF
--- a/i3-v-h-split-label-swap.patch
+++ b/i3-v-h-split-label-swap.patch
@@ -1,0 +1,15 @@
+diff -ruN a/src/con.c b/src/con.c
+--- a/src/con.c	2019-08-30 23:19:35.000000000 +0200
++++ b/src/con.c	2019-10-24 01:19:38.847826361 +0200
+@@ -2212,9 +2212,9 @@
+     if (con->layout == L_DEFAULT)
+         buf = sstrdup("D[");
+     else if (con->layout == L_SPLITV)
+-        buf = sstrdup("V[");
+-    else if (con->layout == L_SPLITH)
+         buf = sstrdup("H[");
++    else if (con->layout == L_SPLITH)
++        buf = sstrdup("V[");
+     else if (con->layout == L_TABBED)
+         buf = sstrdup("T[");
+     else if (con->layout == L_STACKED)

--- a/i3-v-h-split-label-swap.patch
+++ b/i3-v-h-split-label-swap.patch
@@ -2,14 +2,14 @@ diff -ruN a/src/con.c b/src/con.c
 --- a/src/con.c	2019-08-30 23:19:35.000000000 +0200
 +++ b/src/con.c	2019-10-24 01:19:38.847826361 +0200
 @@ -2212,9 +2212,9 @@
-     if (con->layout == L_DEFAULT)
+     if (con->layout == L_DEFAULT) {
          buf = sstrdup("D[");
-     else if (con->layout == L_SPLITV)
+     } else if (con->layout == L_SPLITV) {
 -        buf = sstrdup("V[");
--    else if (con->layout == L_SPLITH)
+-    } else if (con->layout == L_SPLITH) {
          buf = sstrdup("H[");
-+    else if (con->layout == L_SPLITH)
++    } else if (con->layout == L_SPLITH) {
 +        buf = sstrdup("V[");
-     else if (con->layout == L_TABBED)
+     } else if (con->layout == L_TABBED) {
          buf = sstrdup("T[");
-     else if (con->layout == L_STACKED)
+     } else if (con->layout == L_STACKED) {

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -45,7 +45,7 @@ diff -ruN a/include/window.h b/include/window.h
 @@ -95,3 +95,9 @@
   *
   */
- void window_update_motif_hints(i3Window *win, xcb_get_property_reply_t *prop, border_style_t *motif_border_style);
+ void window_update_machine(i3Window *win, xcb_get_property_reply_t *prop);
 +
 +/**
 + * Updates the _NET_WM_ICON
@@ -122,9 +122,9 @@ diff -ruN a/src/handlers.c b/src/handlers.c
   * be found), true otherwise */
  typedef bool (*cb_property_handler_t)(void *data, xcb_connection_t *c, uint8_t state, xcb_window_t window, xcb_atom_t atom, xcb_get_property_reply_t *property);
 @@ -1296,7 +1309,8 @@
-     {0, UINT_MAX, handle_strut_partial_change},
      {0, UINT_MAX, handle_window_type},
      {0, UINT_MAX, handle_i3_floating},
+     {0, 128, handle_machine_change},
 -    {0, 5 * sizeof(uint64_t), handle_motif_hints_change}};
 +    {0, 5 * sizeof(uint64_t), handle_motif_hints_change},
 +    {0, UINT_MAX, handle_windowicon_change}};
@@ -132,10 +132,10 @@ diff -ruN a/src/handlers.c b/src/handlers.c
  
  /*
 @@ -1318,6 +1332,7 @@
-     property_handlers[9].atom = A__NET_WM_WINDOW_TYPE;
      property_handlers[10].atom = A_I3_FLOATING_WINDOW;
-     property_handlers[11].atom = A__MOTIF_WM_HINTS;
-+    property_handlers[12].atom = A__NET_WM_ICON;
+     property_handlers[11].atom = XCB_ATOM_WM_CLIENT_MACHINE;
+     property_handlers[12].atom = A__MOTIF_WM_HINTS;
++    property_handlers[13].atom = A__NET_WM_ICON;
  }
  
  static void property_notify(uint8_t state, xcb_window_t window, xcb_atom_t atom) {
@@ -152,9 +152,9 @@ diff -ruN a/src/manage.c b/src/manage.c
  
      /* Check if the window is mapped (it could be not mapped when intializing and
 @@ -164,6 +166,7 @@
-     motif_wm_hints_cookie = GET_PROPERTY(A__MOTIF_WM_HINTS, 5 * sizeof(uint64_t));
      wm_user_time_cookie = GET_PROPERTY(A__NET_WM_USER_TIME, UINT32_MAX);
      wm_desktop_cookie = GET_PROPERTY(A__NET_WM_DESKTOP, UINT32_MAX);
+     wm_machine_cookie = GET_PROPERTY(XCB_ATOM_WM_CLIENT_MACHINE, UINT32_MAX);
 +    wm_icon_cookie = GET_PROPERTY(A__NET_WM_ICON, UINT32_MAX);
  
      i3Window *cwindow = scalloc(1, sizeof(i3Window));

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -160,9 +160,9 @@ diff -ruN a/src/manage.c b/src/manage.c
      i3Window *cwindow = scalloc(1, sizeof(i3Window));
      cwindow->id = window;
 @@ -177,6 +180,7 @@
-     window_update_class(cwindow, xcb_get_property_reply(conn, class_cookie, NULL), true);
-     window_update_name_legacy(cwindow, xcb_get_property_reply(conn, title_cookie, NULL), true);
-     window_update_name(cwindow, xcb_get_property_reply(conn, utf8_title_cookie, NULL), true);
+     window_update_class(cwindow, xcb_get_property_reply(conn, class_cookie, NULL));
+     window_update_name_legacy(cwindow, xcb_get_property_reply(conn, title_cookie, NULL));
+     window_update_name(cwindow, xcb_get_property_reply(conn, utf8_title_cookie, NULL));
 +    window_update_icon(cwindow, xcb_get_property_reply(conn, wm_icon_cookie, NULL));
      window_update_leader(cwindow, xcb_get_property_reply(conn, leader_cookie, NULL));
      window_update_transient_for(cwindow, xcb_get_property_reply(conn, transient_cookie, NULL));

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -122,9 +122,9 @@ diff -ruN a/src/handlers.c b/src/handlers.c
   * be found), true otherwise */
  typedef bool (*cb_property_handler_t)(void *data, xcb_connection_t *c, uint8_t state, xcb_window_t window, xcb_atom_t atom, xcb_get_property_reply_t *property);
 @@ -1296,7 +1309,8 @@
-     {0, 128, handle_class_change},
      {0, UINT_MAX, handle_strut_partial_change},
      {0, UINT_MAX, handle_window_type},
+     {0, UINT_MAX, handle_i3_floating},
 -    {0, 5 * sizeof(uint64_t), handle_motif_hints_change}};
 +    {0, 5 * sizeof(uint64_t), handle_motif_hints_change},
 +    {0, UINT_MAX, handle_windowicon_change}};

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -132,10 +132,10 @@ diff -ruN a/src/handlers.c b/src/handlers.c
  
  /*
 @@ -1318,6 +1332,7 @@
-     property_handlers[8].atom = A__NET_WM_STRUT_PARTIAL;
      property_handlers[9].atom = A__NET_WM_WINDOW_TYPE;
-     property_handlers[10].atom = A__MOTIF_WM_HINTS;
-+    property_handlers[11].atom = A__NET_WM_ICON;
+     property_handlers[10].atom = A_I3_FLOATING_WINDOW;
+     property_handlers[11].atom = A__MOTIF_WM_HINTS;
++    property_handlers[12].atom = A__NET_WM_ICON;
  }
  
  static void property_notify(uint8_t state, xcb_window_t window, xcb_atom_t atom) {

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -1,7 +1,6 @@
-diff --git a/include/atoms_rest.xmacro b/include/atoms_rest.xmacro
-index d461dc08..f32a7e1e 100644
---- a/include/atoms_rest.xmacro
-+++ b/include/atoms_rest.xmacro
+diff -ruN a/include/atoms_rest.xmacro b/include/atoms_rest.xmacro
+--- a/include/atoms_rest.xmacro	2019-07-05 10:48:11.623568764 +0200
++++ b/include/atoms_rest.xmacro	2019-07-05 10:46:57.317131827 +0200
 @@ -1,6 +1,7 @@
  xmacro(_NET_WM_USER_TIME)
  xmacro(_NET_STARTUP_ID)
@@ -10,27 +9,25 @@ index d461dc08..f32a7e1e 100644
  xmacro(WM_PROTOCOLS)
  xmacro(WM_DELETE_WINDOW)
  xmacro(UTF8_STRING)
-diff --git a/include/data.h b/include/data.h
-index a729b21e..faed55ee 100644
---- a/include/data.h
-+++ b/include/data.h
-@@ -440,6 +440,11 @@ struct Window {
+diff -ruN a/include/data.h b/include/data.h
+--- a/include/data.h	2019-07-05 10:48:11.623568764 +0200
++++ b/include/data.h	2019-07-05 10:46:57.317131827 +0200
+@@ -504,6 +504,11 @@
+     double min_aspect_ratio;
+     double max_aspect_ratio;
  
-     /* aspect ratio from WM_NORMAL_HINTS (MPlayer uses this for example) */
-     double aspect_ratio;
-+
 +    /** Window icon, as array of ARGB pixels */
 +    uint32_t* icon;
 +    int icon_width;
 +    int icon_height;
- };
- 
- /**
-diff --git a/include/libi3.h b/include/libi3.h
-index 11ca3127..35174f2d 100644
---- a/include/libi3.h
-+++ b/include/libi3.h
-@@ -586,6 +586,11 @@ color_t draw_util_hex_to_color(const char *color);
++
+     /** The window has a nonrectangular shape. */
+     bool shaped;
+     /** The window has a nonrectangular input shape. */
+diff -ruN a/include/libi3.h b/include/libi3.h
+--- a/include/libi3.h	2019-07-05 10:48:11.623568764 +0200
++++ b/include/libi3.h	2019-07-05 10:46:57.317131827 +0200
+@@ -615,6 +615,11 @@
  void draw_util_text(i3String *text, surface_t *surface, color_t fg_color, color_t bg_color, int x, int y, int max_width);
  
  /**
@@ -42,11 +39,10 @@ index 11ca3127..35174f2d 100644
   * Draws a filled rectangle.
   * This function is a convenience wrapper and takes care of flushing the
   * surface as well as restoring the cairo state.
-diff --git a/include/window.h b/include/window.h
-index 77e3f48f..894ee9fd 100644
---- a/include/window.h
-+++ b/include/window.h
-@@ -89,3 +89,9 @@ void window_update_hints(i3Window *win, xcb_get_property_reply_t *prop, bool *ur
+diff -ruN a/include/window.h b/include/window.h
+--- a/include/window.h	2019-07-05 10:48:11.627568896 +0200
++++ b/include/window.h	2019-07-05 10:46:57.317131827 +0200
+@@ -95,3 +95,9 @@
   *
   */
  void window_update_motif_hints(i3Window *win, xcb_get_property_reply_t *prop, border_style_t *motif_border_style);
@@ -56,11 +52,10 @@ index 77e3f48f..894ee9fd 100644
 + *
 + */
 +void window_update_icon(i3Window *win, xcb_get_property_reply_t *prop);
-diff --git a/libi3/draw_util.c b/libi3/draw_util.c
-index e471405b..329b6851 100644
---- a/libi3/draw_util.c
-+++ b/libi3/draw_util.c
-@@ -135,6 +135,42 @@ void draw_util_text(i3String *text, surface_t *surface, color_t fg_color, color_
+diff -ruN a/libi3/draw_util.c b/libi3/draw_util.c
+--- a/libi3/draw_util.c	2019-07-05 10:48:11.627568896 +0200
++++ b/libi3/draw_util.c	2019-07-05 10:46:57.317131827 +0200
+@@ -140,6 +140,42 @@
      cairo_surface_mark_dirty(surface->surface);
  }
  
@@ -100,14 +95,13 @@ index e471405b..329b6851 100644
 +    cairo_restore(surface->cr);
 +}
 +
- /**
+ /*
   * Draws a filled rectangle.
   * This function is a convenience wrapper and takes care of flushing the
-diff --git a/src/handlers.c b/src/handlers.c
-index 7dfacef7..37bd70cf 100644
---- a/src/handlers.c
-+++ b/src/handlers.c
-@@ -1287,6 +1287,19 @@ static bool handle_strut_partial_change(void *data, xcb_connection_t *conn, uint
+diff -ruN a/src/handlers.c b/src/handlers.c
+--- a/src/handlers.c	2019-07-05 10:48:11.635569158 +0200
++++ b/src/handlers.c	2019-07-05 10:46:57.317131827 +0200
+@@ -1275,6 +1275,19 @@
      return true;
  }
  
@@ -127,7 +121,7 @@ index 7dfacef7..37bd70cf 100644
  /* Returns false if the event could not be processed (e.g. the window could not
   * be found), true otherwise */
  typedef bool (*cb_property_handler_t)(void *data, xcb_connection_t *c, uint8_t state, xcb_window_t window, xcb_atom_t atom, xcb_get_property_reply_t *property);
-@@ -1308,7 +1321,8 @@ static struct property_handler_t property_handlers[] = {
+@@ -1296,7 +1309,8 @@
      {0, 128, handle_class_change},
      {0, UINT_MAX, handle_strut_partial_change},
      {0, UINT_MAX, handle_window_type},
@@ -137,7 +131,7 @@ index 7dfacef7..37bd70cf 100644
  #define NUM_HANDLERS (sizeof(property_handlers) / sizeof(struct property_handler_t))
  
  /*
-@@ -1330,6 +1344,7 @@ void property_handlers_init(void) {
+@@ -1318,6 +1332,7 @@
      property_handlers[8].atom = A__NET_WM_STRUT_PARTIAL;
      property_handlers[9].atom = A__NET_WM_WINDOW_TYPE;
      property_handlers[10].atom = A__MOTIF_WM_HINTS;
@@ -145,11 +139,10 @@ index 7dfacef7..37bd70cf 100644
  }
  
  static void property_notify(uint8_t state, xcb_window_t window, xcb_atom_t atom) {
-diff --git a/src/manage.c b/src/manage.c
-index 81ee16fd..233333b1 100644
---- a/src/manage.c
-+++ b/src/manage.c
-@@ -91,6 +91,8 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
+diff -ruN a/src/manage.c b/src/manage.c
+--- a/src/manage.c	2019-07-05 10:48:11.635569158 +0200
++++ b/src/manage.c	2019-07-05 10:46:57.317131827 +0200
+@@ -93,6 +93,8 @@
          role_cookie, startup_id_cookie, wm_hints_cookie,
          wm_normal_hints_cookie, motif_wm_hints_cookie, wm_user_time_cookie, wm_desktop_cookie;
  
@@ -158,15 +151,15 @@ index 81ee16fd..233333b1 100644
      geomc = xcb_get_geometry(conn, d);
  
      /* Check if the window is mapped (it could be not mapped when intializing and
-@@ -162,6 +164,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
+@@ -164,6 +166,7 @@
      motif_wm_hints_cookie = GET_PROPERTY(A__MOTIF_WM_HINTS, 5 * sizeof(uint64_t));
      wm_user_time_cookie = GET_PROPERTY(A__NET_WM_USER_TIME, UINT32_MAX);
      wm_desktop_cookie = GET_PROPERTY(A__NET_WM_DESKTOP, UINT32_MAX);
 +    wm_icon_cookie = GET_PROPERTY(A__NET_WM_ICON, UINT32_MAX);
  
-     DLOG("Managing window 0x%08x\n", window);
- 
-@@ -177,6 +180,7 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
+     i3Window *cwindow = scalloc(1, sizeof(i3Window));
+     cwindow->id = window;
+@@ -177,6 +180,7 @@
      window_update_class(cwindow, xcb_get_property_reply(conn, class_cookie, NULL), true);
      window_update_name_legacy(cwindow, xcb_get_property_reply(conn, title_cookie, NULL), true);
      window_update_name(cwindow, xcb_get_property_reply(conn, utf8_title_cookie, NULL), true);
@@ -174,20 +167,19 @@ index 81ee16fd..233333b1 100644
      window_update_leader(cwindow, xcb_get_property_reply(conn, leader_cookie, NULL));
      window_update_transient_for(cwindow, xcb_get_property_reply(conn, transient_cookie, NULL));
      window_update_strut_partial(cwindow, xcb_get_property_reply(conn, strut_cookie, NULL));
-@@ -185,6 +189,8 @@ void manage_window(xcb_window_t window, xcb_get_window_attributes_cookie_t cooki
+@@ -185,6 +189,8 @@
      window_update_hints(cwindow, xcb_get_property_reply(conn, wm_hints_cookie, NULL), &urgency_hint);
      border_style_t motif_border_style = BS_NORMAL;
      window_update_motif_hints(cwindow, xcb_get_property_reply(conn, motif_wm_hints_cookie, NULL), &motif_border_style);
 +
 +
-     xcb_size_hints_t wm_size_hints;
-     if (!xcb_icccm_get_wm_size_hints_reply(conn, wm_normal_hints_cookie, &wm_size_hints, NULL))
-         memset(&wm_size_hints, '\0', sizeof(xcb_size_hints_t));
-diff --git a/src/render.c b/src/render.c
-index 85548f26..6380f51a 100644
---- a/src/render.c
-+++ b/src/render.c
-@@ -125,6 +125,10 @@ void render_con(Con *con, bool render_fullscreen) {
+     window_update_normal_hints(cwindow, xcb_get_property_reply(conn, wm_normal_hints_cookie, NULL), geom);
+     xcb_get_property_reply_t *type_reply = xcb_get_property_reply(conn, wm_type_cookie, NULL);
+     xcb_get_property_reply_t *state_reply = xcb_get_property_reply(conn, state_cookie, NULL);
+diff -ruN a/src/render.c b/src/render.c
+--- a/src/render.c	2019-07-05 10:48:11.639569289 +0200
++++ b/src/render.c	2019-07-05 10:46:57.317131827 +0200
+@@ -125,6 +125,10 @@
      /* find the height for the decorations */
      params.deco_height = render_deco_height();
  
@@ -198,11 +190,10 @@ index 85548f26..6380f51a 100644
      /* precalculate the sizes to be able to correct rounding errors */
      params.sizes = precalculate_sizes(con, &params);
  
-diff --git a/src/window.c b/src/window.c
-index db6215d0..5b694593 100644
---- a/src/window.c
-+++ b/src/window.c
-@@ -17,6 +17,7 @@ void window_free(i3Window *win) {
+diff -ruN a/src/window.c b/src/window.c
+--- a/src/window.c	2019-07-05 10:48:11.639569289 +0200
++++ b/src/window.c	2019-07-05 10:46:57.317131827 +0200
+@@ -17,6 +17,7 @@
      FREE(win->class_class);
      FREE(win->class_instance);
      i3string_free(win->name);
@@ -210,7 +201,7 @@ index db6215d0..5b694593 100644
      FREE(win->ran_assignments);
      FREE(win);
  }
-@@ -365,3 +366,75 @@ void window_update_motif_hints(i3Window *win, xcb_get_property_reply_t *prop, bo
+@@ -476,3 +477,75 @@
  #undef MWM_DECOR_BORDER
  #undef MWM_DECOR_TITLE
  }
@@ -286,44 +277,44 @@ index db6215d0..5b694593 100644
 +
 +    FREE(prop);
 +}
-diff --git a/src/x.c b/src/x.c
-index 8d7d3dd8..4dcd2c60 100644
---- a/src/x.c
-+++ b/src/x.c
-@@ -563,6 +563,7 @@
+diff -ruN a/src/x.c b/src/x.c
+--- a/src/x.c	2019-07-05 10:48:11.639569289 +0200
++++ b/src/x.c	2019-07-05 11:01:37.585990087 +0200
+@@ -618,6 +618,10 @@
  
      /* 6: draw the title */
      int text_offset_y = (con->deco_rect.height - config.font.height) / 2;
 +    int text_offset_x = 0;
++    struct Window *win = con->window;
++    if (win != NULL && win->icon)
++        text_offset_x = 18;
  
-     struct Window *win = con->window;
-     if (win == NULL) {
-@@ -589,6 +590,9 @@
-         goto after_title;
+     const int title_padding = logical_px(2);
+     const int deco_width = (int)con->deco_rect.width;
+@@ -659,7 +663,6 @@
      }
  
-+    if (win->icon)
-+        text_offset_x = 18;
-+
-     int mark_width = 0;
-     if (config.show_marks && !TAILQ_EMPTY(&(con->marks_head))) {
-         char *formatted_mark = sstrdup("");
-@@ -628,14 +632,32 @@
+     i3String *title = NULL;
+-    struct Window *win = con->window;
+     if (win == NULL) {
+         if (con->title_format == NULL) {
+             char *_title;
+@@ -703,14 +706,32 @@
  
      draw_util_text(title, &(parent->frame_buffer),
                     p->color->text, p->color->background,
--                   con->deco_rect.x + logical_px(2),
-+                   con->deco_rect.x + text_offset_x + logical_px(2),
+-                   con->deco_rect.x + title_offset_x,
++                   con->deco_rect.x + text_offset_x + title_offset_x,
                     con->deco_rect.y + text_offset_y,
--                   con->deco_rect.width - mark_width - 2 * logical_px(2));
-+                   con->deco_rect.width - text_offset_x - mark_width - 2 * logical_px(2));
+-                   deco_width - mark_width - 2 * title_padding);
++                   deco_width - text_offset_x - mark_width - 2 * title_padding);
  
-     if (con->title_format != NULL) {
+     if (win == NULL || con->title_format != NULL) {
          I3STRING_FREE(title);
      }
  
 +    /* Draw the icon */
-+    if (win->icon) {
++    if (win != NULL && win->icon) {
 +        uint16_t width = 16;
 +        uint16_t height = 16;
 +
@@ -334,12 +325,12 @@ index 8d7d3dd8..4dcd2c60 100644
 +                win->icon_width,
 +                win->icon_height,
 +                &(parent->frame_buffer),
-+                con->deco_rect.x + logical_px(2),
++                con->deco_rect.x + title_offset_x,
 +                con->deco_rect.y + icon_offset_y,
 +                width,
 +                height);
 +    }
 +
- after_title:
      x_draw_decoration_after_title(con, p);
  copy_pixmaps:
+     draw_util_copy_surface(&(con->frame_buffer), &(con->frame), 0, 0, 0, 0, con->rect.width, con->rect.height);

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -2,13 +2,13 @@ diff -ruN a/include/i3-atoms_rest.xmacro.h b/include/i3-atoms_rest.xmacro.h
 --- a/include/i3-atoms_rest.xmacro.h	2019-07-05 10:48:11.623568764 +0200
 +++ b/include/i3-atoms_rest.xmacro.h	2019-07-05 10:46:57.317131827 +0200
 @@ -1,6 +1,7 @@
- xmacro(_NET_WM_USER_TIME)
- xmacro(_NET_STARTUP_ID)
- xmacro(_NET_WORKAREA)
-+xmacro(_NET_WM_ICON)
- xmacro(WM_PROTOCOLS)
- xmacro(WM_DELETE_WINDOW)
- xmacro(UTF8_STRING)
+xmacro(_NET_WM_USER_TIME) \
+xmacro(_NET_STARTUP_ID) \
+xmacro(_NET_WORKAREA) \
++xmacro(_NET_WM_ICON) \
+xmacro(WM_PROTOCOLS) \
+xmacro(WM_DELETE_WINDOW) \
+xmacro(UTF8_STRING) \
 diff -ruN a/include/data.h b/include/data.h
 --- a/include/data.h	2019-07-05 10:48:11.623568764 +0200
 +++ b/include/data.h	2019-07-05 10:46:57.317131827 +0200

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -2,13 +2,13 @@ diff -ruN a/include/i3-atoms_rest.xmacro.h b/include/i3-atoms_rest.xmacro.h
 --- a/include/i3-atoms_rest.xmacro.h	2019-07-05 10:48:11.623568764 +0200
 +++ b/include/i3-atoms_rest.xmacro.h	2019-07-05 10:46:57.317131827 +0200
 @@ -1,6 +1,7 @@
-xmacro(_NET_WM_USER_TIME) \
-xmacro(_NET_STARTUP_ID) \
-xmacro(_NET_WORKAREA) \
+ xmacro(_NET_WM_USER_TIME) \
+ xmacro(_NET_STARTUP_ID) \
+ xmacro(_NET_WORKAREA) \
 +xmacro(_NET_WM_ICON) \
-xmacro(WM_PROTOCOLS) \
-xmacro(WM_DELETE_WINDOW) \
-xmacro(UTF8_STRING) \
+ xmacro(WM_PROTOCOLS) \
+ xmacro(WM_DELETE_WINDOW) \
+ xmacro(UTF8_STRING) \
 diff -ruN a/include/data.h b/include/data.h
 --- a/include/data.h	2019-07-05 10:48:11.623568764 +0200
 +++ b/include/data.h	2019-07-05 10:46:57.317131827 +0200

--- a/window-icons/window-icons.patch
+++ b/window-icons/window-icons.patch
@@ -1,6 +1,6 @@
-diff -ruN a/include/atoms_rest.xmacro b/include/atoms_rest.xmacro
---- a/include/atoms_rest.xmacro	2019-07-05 10:48:11.623568764 +0200
-+++ b/include/atoms_rest.xmacro	2019-07-05 10:46:57.317131827 +0200
+diff -ruN a/include/i3-atoms_rest.xmacro.h b/include/i3-atoms_rest.xmacro.h
+--- a/include/i3-atoms_rest.xmacro.h	2019-07-05 10:48:11.623568764 +0200
++++ b/include/i3-atoms_rest.xmacro.h	2019-07-05 10:46:57.317131827 +0200
 @@ -1,6 +1,7 @@
  xmacro(_NET_WM_USER_TIME)
  xmacro(_NET_STARTUP_ID)


### PR DESCRIPTION
- note currenlty only works nicely when title_align=left (default);
  could be modified to support centered- and right alignment, but not
  going to for the sake of keeping the patch as simple as possible.